### PR TITLE
could not load inserted library 'skype-poll-fix.dylib' on OS X

### DIFF
--- a/Makefile.macos
+++ b/Makefile.macos
@@ -1,4 +1,4 @@
-CFLAGS=-shared -O2 -ldl
+CFLAGS=-shared -O2 -ldl -arch i386
 
 mac: skype-poll-fix.o
 	$(CC) $(CFLAGS) -o skype-poll-fix.dylib skype-poll-fix.o


### PR DESCRIPTION
I got this error when starting skype (6.17 build 477):

```
» DYLD_INSERT_LIBRARIES=skype-poll-fix.dylib /Applications/Skype.app/Contents/MacOS/Skype
dyld: could not load inserted library 'skype-poll-fix.dylib' because no suitable image found.  Did find:
    skype-poll-fix.dylib: mach-o, but wrong architecture
```

Skype is for i386 architecture, so, here is the fix for that.
