### PR TITLE
fix for Linux: GUI could stale if timeout == 0 changed to timeout > 0

### DIFF
--- a/skype-poll-fix.c
+++ b/skype-poll-fix.c
@@ -63,8 +63,12 @@ int POLL_FUNC_NAME(POLL_FUNC_SIG) {
 		}
 	}
 #ifdef linux
-	if (timeout < MIN_POLL) {
-		timeout = SET_POLL;
+	if (timeout > 0) {
+		if (timeout < 10) {
+			timeout = 10;
+		} else if (timeout < MIN_POLL) {
+			timeout = SET_POLL;
+		}
 	}
 	return pollmethod_orig(fds, nfds, timeout);
 #endif


### PR DESCRIPTION
I have XUbuntu 14.04 and skype could sometimes stall if zero timeouts raised to SET_POLL.

Also, i'm a bit paranoid about small timeouts.

It looks like most timeouts are > 10 msec, so that it still saves CPU utilization.
