### PR TITLE
support isdigit()

### DIFF
--- a/skype-poll-fix.c
+++ b/skype-poll-fix.c
@@ -11,6 +11,7 @@
 #ifdef __APPLE__
 #include <sys/event.h>
 #include <sys/time.h>
+#include <ctype.h>
 #endif
 
 #define _STRINGIZE(x) \


### PR DESCRIPTION
without 

```
#include <ctype.h>
```

 i get:

```
skype-poll-fix.c:37:9: warning: implicit declaration of function 'isdigit' is invalid in C99 [-Wimplicit-function-declaration]
                if ( !isdigit(*str) )
                      ^
```
