### PR TITLE
Clear LD_PRELOAD, MIN_POLL, SET_POLL so they won't be inherited by children

### DIFF
--- a/skype-poll-fix.c
+++ b/skype-poll-fix.c
@@ -51,6 +51,15 @@ int MIN_POLL = 300, SET_POLL = 300;
 
 static __typeof__(&POLL_FUNC_NAME) pollmethod_orig = 0;
 
+__attribute__((constructor))
+static void clear_enviroment(void) {
+	// unset, so binaries launched by Skype (e.g. web browser)
+	// won't inherit these environment variables
+	unsetenv("MIN_POLL");
+	unsetenv("SET_POLL");
+	unsetenv("LD_PRELOAD");
+}
+
 int POLL_FUNC_NAME(POLL_FUNC_SIG) {
 	if (pollmethod_orig == NULL) {
 		pollmethod_orig = dlsym(RTLD_NEXT, STRINGIZE(POLL_FUNC_NAME));


### PR DESCRIPTION
Right now, if you click a link (or open a file) from Skype, application will inherit all the environment, including `LD_PRELOAD`. However, user probably want to apply the fix to Skype itself only.

This patch unsets these variable when library is loaded (it would be Skype, unless the user has a wrapper script, in which case he should put LD_PRELOAD there), so they won't be inherited.

The trick is achieved by means of `__attribute__((constructor))`. 

I have not tested it on Mac.